### PR TITLE
Fix issue #15: stack smash CRASH

### DIFF
--- a/fishtank.ino
+++ b/fishtank.ino
@@ -392,9 +392,9 @@ char* getSystemStatus() {
   char dateTime[24];
   struct tm ti;
   getLocalTime(&ti);
-  char currentTime[40];
+  char currentTime[41];
   char notificationsMuted = EEPROM.read(EEPROM_MUTE_NOTIFICATIONS_BYTE);
-  memset(currentTime, 0, 40);
+  memset(currentTime, 0, 41);
   getDateTimeMyWay(&ti, dateTime, 24);
   sprintf(currentTime, "Readings as of:  %s", dateTime);
   html += currentTime;


### PR DESCRIPTION
This fixes issue #15 
Turns out that 40 bytes is enough for a string like this:
```
9:29:39 AM, 11/27/2021
```
This string is 39 chars, leaving room for a terminating null.
...but add ONE more char to that...
```
10:29:39 AM, 11/27/2021
```
This is 40 chars, no room for null! The `sprintf()` is writing these 40 bytes into the 40 byte buffer on the stack, just like we tell it to. Only problem is now there's no null after it. Maybe. If the next byte on the stack HAPPENS to be 0, then it will act as a terminating null by pure accident. As you may have gathered by now, me and paw are seeing the case where the next byte happens to NOT be 0. Hence, later operations with this string (`char currentTime[40]`) are smashing the stack.