### PR TITLE
Issue #19: no time configuration if can't connect at bootup

### DIFF
--- a/fishtank.ino
+++ b/fishtank.ino
@@ -576,6 +576,7 @@ void connectToWifi()
   if (WiFi.status() == WL_CONNECTED) {
     Serial.println("WiFi connected");
     if (!timeInitialized) {
+      Serial.println("Initializing local time");
       // Looks like this is our first time successfully connecting.
       // Setup the time stuff
       configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);

--- a/fishtank.ino
+++ b/fishtank.ino
@@ -22,7 +22,7 @@ char ssid[] = "ATT4meZ5qR";
 char pass[] = "7xj%4%82sxz5";
 #else
 char ssid[] = "ames";
-char pass[] = "aaadaa00x";
+char pass[] = "aaadaa001";
 #endif
 
 #define NUMBER_OF_AMBIENT_SENSORS 1


### PR DESCRIPTION
Fixes issue #19.

Now it will try to init the time server until it succeeds. After success, it will never try again until next boot.