### PR TITLE
Remove AWS SMS and use email instead

### DIFF
--- a/email.h
+++ b/email.h
@@ -1,0 +1,6 @@
+
+#define SMTP_HOST "smtp.gmail.com"
+#define SMTP_PORT esp_mail_smtp_port_587 // port 465 is not available for Outlook.com
+#define AUTHOR_EMAIL "adamsfishtank@gmail.com"
+#define AUTHOR_PASSWORD "hozr oapb sdgj oppg"
+#define RECIPIENT_EMAIL "danieladamames@gmail.com"

--- a/email.h
+++ b/email.h
@@ -1,6 +1,6 @@
 
 #define SMTP_HOST "smtp.gmail.com"
-#define SMTP_PORT esp_mail_smtp_port_587 // port 465 is not available for Outlook.com
+#define SMTP_PORT esp_mail_smtp_port_587
 #define AUTHOR_EMAIL "adamsfishtank@gmail.com"
 #define AUTHOR_PASSWORD "hozr oapb sdgj oppg"
 #define RECIPIENT_EMAIL1 "adams_dh@sbcglobal.net"

--- a/email.h
+++ b/email.h
@@ -1,7 +1,0 @@
-
-#define SMTP_HOST "smtp.gmail.com"
-#define SMTP_PORT esp_mail_smtp_port_587
-#define AUTHOR_EMAIL "adamsfishtank@gmail.com"
-#define AUTHOR_PASSWORD "hozr oapb sdgj oppg"
-#define RECIPIENT_EMAIL1 "adams_dh@sbcglobal.net"
-#define RECIPIENT_EMAIL2 "danieladamames@gmail.com"

--- a/email.h
+++ b/email.h
@@ -3,4 +3,5 @@
 #define SMTP_PORT esp_mail_smtp_port_587 // port 465 is not available for Outlook.com
 #define AUTHOR_EMAIL "adamsfishtank@gmail.com"
 #define AUTHOR_PASSWORD "hozr oapb sdgj oppg"
-#define RECIPIENT_EMAIL "danieladamames@gmail.com"
+#define RECIPIENT_EMAIL1 "adams_dh@sbcglobal.net"
+#define RECIPIENT_EMAIL2 "danieladamames@gmail.com"

--- a/fishtank.ino
+++ b/fishtank.ino
@@ -1,6 +1,5 @@
 #include <WiFi.h>
 #include <rom/rtc.h>
-//#include <ArduinoJson.h>
 #include <ESP_Mail_Client.h>
 #include <EEPROM.h>
 #include <WebServer.h>
@@ -14,7 +13,7 @@
 
 #define VERSION  "1.5"
 #define DEBUG 0
-#define PRODUCTION_UNIT 0
+#define PRODUCTION_UNIT 1
 
 #if PRODUCTION_UNIT
 char ssid[] = "ATT3HQ3Bhl";
@@ -577,6 +576,12 @@ String getResetReasonString(RESET_REASON reason)
 
 bool sendSmtp(const char* subject, const char* messageStr)
 {
+  char notificationsMuted = EEPROM.read(EEPROM_MUTE_NOTIFICATIONS_BYTE);
+  if (notificationsMuted == 1) {
+     Serial.println("sendSmtp() DISABLED. Notifications muted.");
+     return true;
+  }
+
   SMTP_Message message;
   Session_Config config;
 


### PR DESCRIPTION
Since telecoms have killed long code sms, and I aint about to pay no $300+/month for a short code, looks like we're moving to email notifications. This is actually a bit of a relief since AWS is soooo complicated. Email is so much simpler. I will enjoy deleting my AWS account...